### PR TITLE
Fix php error when ID is not found

### DIFF
--- a/includes/class-campaign.php
+++ b/includes/class-campaign.php
@@ -14,7 +14,9 @@ class ATCF_Campaign {
 
 	function __construct( $post ) {
 		$this->data = get_post( $post );
-		$this->ID   = $this->data->ID;
+		if ($this->data) {
+		  $this->ID   = $this->data->ID;
+		}
 	}
 
 	/**
@@ -26,6 +28,9 @@ class ATCF_Campaign {
 	 * @return string $meta The fetched value
 	 */
 	public function __get( $key ) {
+		if (!$this->data) {
+			return NULL;
+		}
 		$meta = apply_filters( 'atcf_campaign_meta_' . $key, $this->data->__get( $key ) );
 
 		return $meta;


### PR DESCRIPTION
Fixes the following error: 

Getting a Fatal error: Call to a member function __get() on a non-object in /path-to-wordpress/wp-content/plugins/appthemer-crowdfunding/includes/class-campaign.php on line 29